### PR TITLE
Add 0.5 tests badge and enable coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ notifications:
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia -e 'Pkg.clone(pwd()); Pkg.build("DataStreams"); Pkg.test("DataStreams"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("DataStreams")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # DataStreams
 
 [![DataStreams](http://pkg.julialang.org/badges/DataStreams_0.4.svg)](http://pkg.julialang.org/?pkg=DataStreams&ver=0.4)
+[![DataStreams](http://pkg.julialang.org/badges/DataStreams_0.5.svg)](http://pkg.julialang.org/?pkg=DataStreams)
 
-Linux: [![Build Status](https://travis-ci.org/JuliaDB/DataStreams.jl.svg?branch=master)](https://travis-ci.org/JuliaDB/DataStreams.jl)
+Linux and OS X: [![Build Status](https://travis-ci.org/JuliaDB/DataStreams.jl.svg?branch=master)](https://travis-ci.org/JuliaDB/DataStreams.jl)
 
 Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaDB/DataStreams.jl?branch=master&svg=true)](https://ci.appveyor.com/project/JuliaDB/datastreams-jl/branch/master)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ print(sch)
 src_tb = Data.Table(sch)
 
 for i = 1:ROWS, j = 1:COLS
-	src_tb.data[j][i] = i * j
+    src_tb.data[j][i] = i * j
 end
 
 print(src_tb)


### PR DESCRIPTION
I took the 0.5 tests badge directly from the Julia packages site. The README includes a Codecov badge but no coverage information was actually being submitted to Codecov (which is why the coverage is shown as unknown), so I added that in the Travis YAML. I also sneakily replaced the one indenting tab in the repo with four spaces for consistency.