### PR TITLE
Fix Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Linux and OS X: [![Build Status](https://travis-ci.org/JuliaDB/DataStreams.jl.sv
 
 Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaDB/DataStreams.jl?branch=master&svg=true)](https://ci.appveyor.com/project/JuliaDB/datastreams-jl/branch/master)
 
-[![codecov.io](http://codecov.io/github/JuliaDB/DataStreams/coverage.svg?branch=master)](http://codecov.io/github/JuliaDB/DataStreams?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaDB/DataStreams.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDB/DataStreams.jl?branch=master)
 
 The `DataStreams.jl` packages defines a data processing framework based on Sources, Sinks, and the `Data.stream!` function.
 


### PR DESCRIPTION
Looks like everything from Codecov is set up correctly but the URLs for the badge in the README are missing the .jl on the repo name, which is causing the badge to display `unknown`. This corrects the URLs.